### PR TITLE
Add basic enemy AI and spawner systems

### DIFF
--- a/Assets/Scripts/AI.meta
+++ b/Assets/Scripts/AI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dbfb2ec91ce049048c3f76ac78f42bfd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AI/EnemyAIController.cs
+++ b/Assets/Scripts/AI/EnemyAIController.cs
@@ -1,0 +1,191 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace RTSGame.AI
+{
+    /// <summary>
+    /// Basic enemy AI using a simple FSM: Idle, Chase, Attack.
+    /// Prioritises the closest player unit, then the town center, then other buildings.
+    /// </summary>
+    [RequireComponent(typeof(NavMeshAgent))]
+    public class EnemyAIController : MonoBehaviour
+    {
+        private enum State { Idle, Chase, Attack }
+
+        [Header("Targeting")]
+        [SerializeField] private float detectionRadius = 15f;
+        [SerializeField] private float attackRadius = 2f;
+        [SerializeField] private LayerMask targetMask;
+        [SerializeField] private Team team = Team.Enemy;
+        [SerializeField] private float repathTime = 2f;
+
+        [Header("Attack")]
+        [SerializeField] private float damage = 10f;
+        [SerializeField] private float attackInterval = 1f;
+
+        private readonly Collider[] detectionBuffer = new Collider[30];
+        private NavMeshAgent agent;
+        private State state = State.Idle;
+        private Targetable currentTarget;
+        private float lastAttackTime;
+        private float pathFailTimer;
+
+        private void Awake()
+        {
+            agent = GetComponent<NavMeshAgent>();
+        }
+
+        private void Update()
+        {
+            switch (state)
+            {
+                case State.Idle:
+                    HandleIdle();
+                    break;
+                case State.Chase:
+                    HandleChase();
+                    break;
+                case State.Attack:
+                    HandleAttack();
+                    break;
+            }
+        }
+
+        private void HandleIdle()
+        {
+            AcquireTarget();
+            if (currentTarget != null)
+            {
+                state = State.Chase;
+            }
+        }
+
+        private void HandleChase()
+        {
+            if (currentTarget == null || !currentTarget.IsAlive)
+            {
+                state = State.Idle;
+                return;
+            }
+
+            float sqrDist = (currentTarget.TargetTransform.position - transform.position).sqrMagnitude;
+            if (sqrDist > detectionRadius * detectionRadius)
+            {
+                currentTarget = null;
+                state = State.Idle;
+                return;
+            }
+
+            if (sqrDist <= attackRadius * attackRadius)
+            {
+                agent.ResetPath();
+                state = State.Attack;
+                return;
+            }
+
+            if (!agent.hasPath || agent.destination != currentTarget.TargetTransform.position)
+            {
+                agent.SetDestination(currentTarget.TargetTransform.position);
+                pathFailTimer = 0f;
+            }
+
+            if (agent.pathStatus != NavMeshPathStatus.PathComplete)
+            {
+                pathFailTimer += Time.deltaTime;
+                if (pathFailTimer >= repathTime)
+                {
+                    AcquireTarget();
+                    pathFailTimer = 0f;
+                }
+            }
+        }
+
+        private void HandleAttack()
+        {
+            if (currentTarget == null || !currentTarget.IsAlive)
+            {
+                state = State.Idle;
+                return;
+            }
+
+            float sqrDist = (currentTarget.TargetTransform.position - transform.position).sqrMagnitude;
+            if (sqrDist > attackRadius * attackRadius)
+            {
+                state = State.Chase;
+                return;
+            }
+
+            agent.ResetPath();
+            transform.LookAt(currentTarget.TargetTransform.position);
+
+            if (Time.time - lastAttackTime >= attackInterval)
+            {
+                lastAttackTime = Time.time;
+                currentTarget.Health.ApplyDamage(damage);
+                if (!currentTarget.IsAlive)
+                {
+                    currentTarget = null;
+                    state = State.Idle;
+                }
+            }
+        }
+
+        private void AcquireTarget()
+        {
+            currentTarget = FindBestTarget();
+            if (currentTarget != null)
+            {
+                agent.SetDestination(currentTarget.TargetTransform.position);
+                state = State.Chase;
+            }
+        }
+
+        private Targetable FindBestTarget()
+        {
+            int hits = Physics.OverlapSphereNonAlloc(transform.position, detectionRadius, detectionBuffer, targetMask);
+            Targetable nearestUnit = null;
+            float nearestUnitDist = float.MaxValue;
+            Targetable townCenter = null;
+            Targetable building = null;
+
+            for (int i = 0; i < hits; i++)
+            {
+                Targetable t = detectionBuffer[i].GetComponent<Targetable>();
+                if (t == null || !TeamHelper.IsEnemy(team, t.Team) || !t.IsAlive)
+                    continue;
+
+                float dist = (t.TargetTransform.position - transform.position).sqrMagnitude;
+                if (!t.IsBuilding)
+                {
+                    if (dist < nearestUnitDist)
+                    {
+                        nearestUnitDist = dist;
+                        nearestUnit = t;
+                    }
+                }
+                else
+                {
+                    if (t.IsTownCenter)
+                    {
+                        townCenter = t;
+                    }
+                    else if (building == null)
+                    {
+                        building = t;
+                    }
+                }
+            }
+
+            return nearestUnit ?? townCenter ?? building;
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawWireSphere(transform.position, detectionRadius);
+            Gizmos.color = Color.red;
+            Gizmos.DrawWireSphere(transform.position, attackRadius);
+        }
+    }
+}

--- a/Assets/Scripts/AI/EnemyAIController.cs.meta
+++ b/Assets/Scripts/AI/EnemyAIController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ca1a0edd7314cb49570d40e2c5df8d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AI/EnemySpawner.cs
+++ b/Assets/Scripts/AI/EnemySpawner.cs
@@ -1,0 +1,88 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace RTSGame.AI
+{
+    /// <summary>
+    /// Spawns enemy units either continuously or in waves.
+    /// </summary>
+    public class EnemySpawner : MonoBehaviour
+    {
+        private enum SpawnMode { Continuous, Waves }
+
+        [SerializeField] private List<GameObject> enemyPrefabs = new List<GameObject>();
+        [SerializeField] private Transform[] spawnPoints;
+        [SerializeField] private SpawnMode mode = SpawnMode.Continuous;
+
+        [Header("Continuous")]
+        [SerializeField] private float spawnInterval = 5f;
+
+        [Header("Waves")]
+        [SerializeField] private int enemiesPerWave = 5;
+        [SerializeField] private float timeBetweenWaves = 20f;
+        [SerializeField] private float difficultyFactor = 1.1f;
+
+        [Header("General")]
+        [SerializeField] private int maxAlive = 25;
+        [SerializeField] private Team team = Team.Enemy;
+
+        private readonly List<Health> alive = new List<Health>();
+        private int waveIndex = 0;
+
+        private void Start()
+        {
+            StartCoroutine(mode == SpawnMode.Waves ? WaveRoutine() : ContinuousRoutine());
+        }
+
+        private IEnumerator ContinuousRoutine()
+        {
+            while (true)
+            {
+                if (alive.Count < maxAlive)
+                {
+                    SpawnEnemy();
+                }
+                yield return new WaitForSeconds(spawnInterval);
+            }
+        }
+
+        private IEnumerator WaveRoutine()
+        {
+            while (true)
+            {
+                int count = Mathf.RoundToInt(enemiesPerWave * Mathf.Pow(difficultyFactor, waveIndex));
+                for (int i = 0; i < count; i++)
+                {
+                    SpawnEnemy();
+                    yield return null; // spread spawns over frames
+                }
+                waveIndex++;
+                yield return new WaitForSeconds(timeBetweenWaves);
+            }
+        }
+
+        private void SpawnEnemy()
+        {
+            if (enemyPrefabs.Count == 0 || spawnPoints == null || spawnPoints.Length == 0)
+                return;
+
+            GameObject prefab = enemyPrefabs[Random.Range(0, enemyPrefabs.Count)];
+            Transform point = spawnPoints[Random.Range(0, spawnPoints.Length)];
+            GameObject instance = Instantiate(prefab, point.position, point.rotation);
+
+            Targetable targetable = instance.GetComponent<Targetable>();
+            if (targetable != null)
+            {
+                targetable.Team = team;
+            }
+
+            Health health = instance.GetComponent<Health>();
+            if (health != null)
+            {
+                alive.Add(health);
+                health.OnDeath.AddListener(() => alive.Remove(health));
+            }
+        }
+    }
+}

--- a/Assets/Scripts/AI/EnemySpawner.cs.meta
+++ b/Assets/Scripts/AI/EnemySpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1c618c1c554405297ebd8711561d1f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AI/Health.cs
+++ b/Assets/Scripts/AI/Health.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace RTSGame.AI
+{
+    /// <summary>
+    /// Simple health component with damage and death event.
+    /// </summary>
+    public class Health : MonoBehaviour
+    {
+        [SerializeField] private float maxHP = 100f;
+        public float MaxHP => maxHP;
+        public float CurrentHP { get; private set; }
+
+        /// <summary>
+        /// Invoked when health reaches zero.
+        /// </summary>
+        public UnityEvent OnDeath = new UnityEvent();
+
+        private void Awake()
+        {
+            CurrentHP = maxHP;
+        }
+
+        /// <summary>
+        /// Apply damage to this object. Negative values heal.
+        /// </summary>
+        public void ApplyDamage(float amount)
+        {
+            if (CurrentHP <= 0f) return;
+            CurrentHP = Mathf.Clamp(CurrentHP - amount, 0f, maxHP);
+            if (CurrentHP <= 0f)
+            {
+                OnDeath.Invoke();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/AI/Health.cs.meta
+++ b/Assets/Scripts/AI/Health.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed81ea807e534fe4b8bf27549cc0d92b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AI/Targetable.cs
+++ b/Assets/Scripts/AI/Targetable.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+namespace RTSGame.AI
+{
+    /// <summary>
+    /// Marks an entity as a potential target for AI units.
+    /// </summary>
+    [RequireComponent(typeof(Health))]
+    public class Targetable : MonoBehaviour
+    {
+        [SerializeField] private Team team = Team.Player;
+        [SerializeField] private bool isBuilding = false;
+        [SerializeField] private bool isTownCenter = false;
+
+        public Team Team
+        {
+            get => team;
+            set => team = value;
+        }
+
+        public bool IsBuilding => isBuilding;
+        public bool IsTownCenter => isTownCenter;
+        public Transform TargetTransform => transform;
+        public Health Health { get; private set; }
+        public bool IsAlive => Health != null && Health.CurrentHP > 0f;
+
+        private void Awake()
+        {
+            Health = GetComponent<Health>();
+        }
+    }
+}

--- a/Assets/Scripts/AI/Targetable.cs.meta
+++ b/Assets/Scripts/AI/Targetable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a92b301ab7ad4b0da47180200ccc2069
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AI/Team.cs
+++ b/Assets/Scripts/AI/Team.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+namespace RTSGame.AI
+{
+    /// <summary>
+    /// Basic team identifiers. Extend as needed.
+    /// </summary>
+    public enum Team
+    {
+        Player,
+        Enemy
+    }
+
+    public static class TeamHelper
+    {
+        public static bool IsEnemy(Team a, Team b) => a != b;
+    }
+}

--- a/Assets/Scripts/AI/Team.cs.meta
+++ b/Assets/Scripts/AI/Team.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c171fded1888412998c86f0d74d91bba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add Health and Targetable components
- implement EnemyAIController with simple FSM and targeting rules
- add configurable EnemySpawner and Team helper

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689696ce252c832cb4c46f337be73454