### PR TITLE
Remove NUnit reference from runtime script

### DIFF
--- a/Assets/Scripts/UnitSelectionManager.cs
+++ b/Assets/Scripts/UnitSelectionManager.cs
@@ -1,4 +1,3 @@
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;


### PR DESCRIPTION
## Summary
- remove NUnit using directive from UnitSelectionManager
- verify no runtime scripts reference NUnit

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689a8b0d2e40832c886453566e2c8084