### PR TITLE
Optimize unit detection and tracking

### DIFF
--- a/Assets/Scripts/EnemigoIA.cs
+++ b/Assets/Scripts/EnemigoIA.cs
@@ -48,18 +48,25 @@ public class EnemigoIA : MonoBehaviour, IDamageable
 
     public UnidadMilitar BuscarUnidadCercana()
     {
-        UnidadMilitar[] unidades = FindObjectsOfType<UnidadMilitar>();
+        Collider[] colliders = Physics.OverlapSphere(transform.position, 10f);
+        UnidadMilitar masCercana = null;
+        float minDistancia = Mathf.Infinity;
 
-        foreach (UnidadMilitar unidad in unidades)
+        foreach (Collider col in colliders)
         {
-            float distancia = Vector3.Distance(transform.position, unidad.transform.position);
-            if (distancia < 10f) // rango de detección
+            UnidadMilitar unidad = col.GetComponent<UnidadMilitar>();
+            if (unidad != null)
             {
-                return unidad;
+                float distancia = Vector3.Distance(transform.position, unidad.transform.position);
+                if (distancia < minDistancia)
+                {
+                    minDistancia = distancia;
+                    masCercana = unidad;
+                }
             }
         }
 
-        return null;
+        return masCercana;
     }
 
 

--- a/Assets/Scripts/EstadoAtacar.cs
+++ b/Assets/Scripts/EstadoAtacar.cs
@@ -83,17 +83,24 @@ public class EstadoAtacar : IEstadoUnidadIA
 
     private UnidadMilitar BuscarUnidadCercana(EnemigoIA contexto)
     {
-        UnidadMilitar[] unidades = GameObject.FindObjectsOfType<UnidadMilitar>();
+        Collider[] colliders = Physics.OverlapSphere(contexto.transform.position, 8f);
+        UnidadMilitar masCercana = null;
+        float minDistancia = Mathf.Infinity;
 
-        foreach (UnidadMilitar unidad in unidades)
+        foreach (Collider col in colliders)
         {
-            float distancia = Vector3.Distance(contexto.transform.position, unidad.transform.position);
-            if (distancia < 8f)
+            UnidadMilitar unidad = col.GetComponent<UnidadMilitar>();
+            if (unidad != null)
             {
-                return unidad;
+                float distancia = Vector3.Distance(contexto.transform.position, unidad.transform.position);
+                if (distancia < minDistancia)
+                {
+                    minDistancia = distancia;
+                    masCercana = unidad;
+                }
             }
         }
 
-        return null;
+        return masCercana;
     }
 }

--- a/Assets/Scripts/SeleccionMultiple.cs
+++ b/Assets/Scripts/SeleccionMultiple.cs
@@ -32,7 +32,7 @@ public class SeleccionMultiple : MonoBehaviour
         {
             unidadesSeleccionadas.Clear();
 
-            foreach (UnidadMilitar unidad in FindObjectsOfType<UnidadMilitar>())
+            foreach (UnidadMilitar unidad in UnidadMilitar.unidadesAliadas)
             {
                 Vector3 pantallaPos = Camera.main.WorldToScreenPoint(unidad.transform.position);
                 pantallaPos.y = Screen.height - pantallaPos.y;

--- a/Assets/Scripts/UIRecursosTMP.cs
+++ b/Assets/Scripts/UIRecursosTMP.cs
@@ -12,7 +12,7 @@ public class UIRecursosTMP : MonoBehaviour
     {
         textoOro.text = "Oro: " + GameManager.Instance.oro;
 
-        int cantidadU = GameObject.FindObjectsOfType<UnidadMilitar>().Length;
+        int cantidadU = UnidadMilitar.unidadesAliadas.Count;
         textoUnidades.text = "Unidades: " + cantidadU;
 
         int cantidadE = GameObject.FindObjectsOfType<EnemigoIA>().Length;

--- a/Assets/Scripts/UnidadMilitar.cs
+++ b/Assets/Scripts/UnidadMilitar.cs
@@ -1,13 +1,26 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 public class UnidadMilitar : MonoBehaviour, IUnidad, IUnidadEjecutable, IDamageable
 {
+    public static List<UnidadMilitar> unidadesAliadas = new List<UnidadMilitar>();
+
     public string tipoUnidad;
     public int vida = 100;
     public float velocidad = 3f;
     public int costoEntrenamiento = 50;
 
     private Vector3? destino = null;
+
+    void OnEnable()
+    {
+        unidadesAliadas.Add(this);
+    }
+
+    void OnDisable()
+    {
+        unidadesAliadas.Remove(this);
+    }
     
     public void TakeDamage(int cantidad)
     {


### PR DESCRIPTION
## Summary
- Track allied units in a global list
- Use Physics.OverlapSphere to find nearby units for enemies
- Replace scene-wide searches with list-based selection and UI counts

## Testing
- `dotnet test` *(fails: MSB1003 no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689a8b0daa74832c96e41952c1ae4219