### PR TITLE
Gestión centralizada de enemigos en GameManager

### DIFF
--- a/Assets/Scripts/EnemigoIA.cs
+++ b/Assets/Scripts/EnemigoIA.cs
@@ -22,6 +22,7 @@ public class EnemigoIA : MonoBehaviour, IDamageable
         if (vida <= 0)
         {
             Debug.Log(name + " ha sido destruido.");
+            GameManager.Instance.UnregisterEnemy();
             Destroy(gameObject);
         }
     }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,10 +1,15 @@
 using UnityEngine;
+using System;
 
 public class GameManager : MonoBehaviour
 {
     public static GameManager Instance { get; private set; }
 
     public int oro = 500; // recurso inicial
+
+    private int enemigosVivos = 0;
+    public int EnemigosVivos => enemigosVivos;
+    public event Action<int> OnEnemigosVivosChange;
 
     void Awake()
     {
@@ -35,6 +40,18 @@ public class GameManager : MonoBehaviour
     {
         oro += cantidad;
         Debug.Log("Oro ganado. Total: " + oro);
+    }
+
+    public void RegisterEnemy()
+    {
+        enemigosVivos++;
+        OnEnemigosVivosChange?.Invoke(enemigosVivos);
+    }
+
+    public void UnregisterEnemy()
+    {
+        enemigosVivos = Mathf.Max(0, enemigosVivos - 1);
+        OnEnemigosVivosChange?.Invoke(enemigosVivos);
     }
     
     public void Victoria()

--- a/Assets/Scripts/OleadasManager.cs
+++ b/Assets/Scripts/OleadasManager.cs
@@ -39,6 +39,8 @@ public class OleadasManager : MonoBehaviour
             Transform punto = puntosSpawn[Random.Range(0, puntosSpawn.Length)];
             GameObject clon = Instantiate(prefabEnemigo, punto.position, Quaternion.identity);
 
+            GameManager.Instance.RegisterEnemy();
+
             // Configurar IA del enemigo si es necesario
             EnemigoIA ia = clon.GetComponent<EnemigoIA>();
             if (ia != null)

--- a/Assets/Scripts/UIRecursosTMP.cs
+++ b/Assets/Scripts/UIRecursosTMP.cs
@@ -8,6 +8,20 @@ public class UIRecursosTMP : MonoBehaviour
     public TMP_Text textoEnemigos;
     public OleadasManager oleadas;
     public TMP_Text textoOleada;
+    void Start()
+    {
+        GameManager.Instance.OnEnemigosVivosChange += ActualizarEnemigos;
+        ActualizarEnemigos(GameManager.Instance.EnemigosVivos);
+    }
+
+    void OnDestroy()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnEnemigosVivosChange -= ActualizarEnemigos;
+        }
+    }
+
     void Update()
     {
         textoOro.text = "Oro: " + GameManager.Instance.oro;
@@ -15,10 +29,12 @@ public class UIRecursosTMP : MonoBehaviour
         int cantidadU = UnidadMilitar.unidadesAliadas.Count;
         textoUnidades.text = "Unidades: " + cantidadU;
 
-        int cantidadE = GameObject.FindObjectsOfType<EnemigoIA>().Length;
-        textoEnemigos.text = "Enemigos: " + cantidadE;
-        
         textoOleada.text = "Oleada: " + oleadas.oleadaActual;
     }
-    
+
+    void ActualizarEnemigos(int cantidad)
+    {
+        textoEnemigos.text = "Enemigos: " + cantidad;
+    }
+
 }


### PR DESCRIPTION
## Summary
- Añade contador y evento de enemigos en `GameManager`.
- Registra enemigos al generarse y los quita al morir.
- `UIRecursosTMP` se suscribe al evento y actualiza el texto de enemigos sólo cuando cambia.

## Testing
- `dotnet test` *(falla: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ac756db38832c9507bf20dd260f22