### PR TITLE
Cache main camera in unit controller

### DIFF
--- a/Assets/Scripts/ControladorUnidades.cs
+++ b/Assets/Scripts/ControladorUnidades.cs
@@ -6,14 +6,18 @@ public class ControladorUnidades : MonoBehaviour
     public SeleccionMultiple selector;
 
     private GrupoUnidades grupoActual = new GrupoUnidades();
+    private Camera mainCamera;
+
+    void Start()
+    {
+        mainCamera = Camera.main;
+    }
 
     void Update()
     {
         if (Input.GetMouseButtonDown(1)) // clic derecho
         {
-            if (grupoActual == null) return;
-
-            Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+            Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
             RaycastHit hit;
 
             if (Physics.Raycast(ray, out hit))


### PR DESCRIPTION
## Summary
- cache Camera.main in ControladorUnidades to avoid repeated lookups
- remove redundant null check before moving groups

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_689ac7578de0832ca8bb821084b7971e